### PR TITLE
Use versioned archive URLs and fix broken SHA256 hashes

### DIFF
--- a/.github/workflows/update-cask.yml
+++ b/.github/workflows/update-cask.yml
@@ -44,10 +44,10 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
 
           echo "Downloading ARM DMG..."
-          curl -L -o whatpulse-arm.dmg "https://releases.whatpulse.org/latest/macos-arm/whatpulse-mac-arm-${VERSION}.dmg"
+          curl -fL -o whatpulse-arm.dmg "https://releases.whatpulse.org/archives/${VERSION}/macos-arm/whatpulse-mac-arm-${VERSION}.dmg"
 
           echo "Downloading Intel DMG..."
-          curl -L -o whatpulse-intel.dmg "https://releases.whatpulse.org/latest/macos/whatpulse-mac-${VERSION}.dmg"
+          curl -fL -o whatpulse-intel.dmg "https://releases.whatpulse.org/archives/${VERSION}/macos/whatpulse-mac-${VERSION}.dmg"
 
           # Verify downloads succeeded (check file size > 0)
           if [ ! -s whatpulse-arm.dmg ]; then

--- a/Casks/whatpulse.rb
+++ b/Casks/whatpulse.rb
@@ -7,12 +7,12 @@ cask 'whatpulse' do
   depends_on cask: 'whatpulse_chmodbpf'
 
   on_arm do
-    url "https://releases.whatpulse.org/latest/macos-arm/whatpulse-mac-arm-#{version}.dmg"
-    sha256 '62c1c0b235e26952857139537b65f8272026cd1c385c1bf6dba20481ee8a6619'
+    url "https://releases.whatpulse.org/archives/#{version}/macos-arm/whatpulse-mac-arm-#{version}.dmg"
+    sha256 '043b6df7f4240e63a9b726e8710197848d6936dcff451c24aa7d976daa425723'
   end
   on_intel do
-    url "https://releases.whatpulse.org/latest/macos/whatpulse-mac-#{version}.dmg"
-    sha256 '62c1c0b235e26952857139537b65f8272026cd1c385c1bf6dba20481ee8a6619'
+    url "https://releases.whatpulse.org/archives/#{version}/macos/whatpulse-mac-#{version}.dmg"
+    sha256 '9c374ffe7817d8a87775d8ae92d721a9c3a0ffb9942f09185b818b9718729e98'
   end
 
   livecheck do


### PR DESCRIPTION
## Problem

The cask and the update-cask workflow use `latest/` URLs, which only host the newest version's filename:

- Fresh `brew install whatpulse` is **currently broken**: `latest/whatpulse-mac-*-6.3.1.dmg` returns 404.
- Both architectures had the **same** SHA256 (`62c1c0b2...`) — the workflow's `curl -L` (without `-f`) saved the 404 error page as the DMG, the non-empty check passed, and both arches hashed the same error page.

## Changes

- Cask URLs now use immutable `archives/#{version}/` paths, so hashes stay valid after later releases.
- Corrected 6.3.1 hashes, computed from the archive DMGs:
  - ARM: `043b6df7f4240e63a9b726e8710197848d6936dcff451c24aa7d976daa425723`
  - Intel: `9c374ffe7817d8a87775d8ae92d721a9c3a0ffb9942f09185b818b9718729e98`
- update-cask workflow downloads from the archive URLs and uses `curl -f` so a 404 fails the run instead of hashing an error page.